### PR TITLE
feat: Image Editor static and use Unsplash API

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,4 +1,4 @@
-import { SERVER_URL } from "@env";
+import { SERVER_URL, UNSPLASH_ACCESS_KEY } from "@env";
 import axios from "axios";
 import * as SecureStore from "expo-secure-store";
 import { Alert } from "react-native";
@@ -6,6 +6,37 @@ import { Alert } from "react-native";
 const axiosInstance = axios.create({
   baseURL: SERVER_URL,
 });
+
+const unsplashInstance = axios.create({
+  baseURL: "https://api.unsplash.com/",
+  headers: {
+    Authorization: `Client-ID ${UNSPLASH_ACCESS_KEY}`,
+  },
+});
+
+async function getImages() {
+  try {
+    const response = await unsplashInstance.get("/photos", {
+      params: { per_page: 30 },
+    });
+
+    return response;
+  } catch (err) {
+    console.log(err);
+  }
+}
+
+async function searchImages(query, page = 1, perPage = 30) {
+  try {
+    const response = await unsplashInstance.get("/search/photos", {
+      params: { query, page, perPage },
+    });
+
+    return response;
+  } catch (err) {
+    console.log(err);
+  }
+}
 
 async function postSignIn(email, password) {
   try {
@@ -60,4 +91,6 @@ export default {
   postSignUp,
   postSignIn,
   getGifs,
+  getImages,
+  searchImages,
 };

--- a/src/constants/footerItems.js
+++ b/src/constants/footerItems.js
@@ -31,3 +31,23 @@ export const gifEditor = [
     text: "More",
   },
 ];
+
+export const imageEditor = [
+  {
+    icon: "MaterialCommunityIcons",
+    iconName: "folder-image",
+    text: "Unsplash",
+  },
+  {
+    icon: "MaterialCommunityIcons",
+    iconName: "image-size-select-large",
+    text: "Size",
+  },
+  { icon: "FontAwesome", iconName: "rotate-left", text: "Left Rotate" },
+  { icon: "FontAwesome", iconName: "rotate-right", text: "Right Rotate" },
+  {
+    icon: "Ionicons",
+    iconName: "ellipsis-horizontal-sharp",
+    text: "More",
+  },
+];

--- a/src/layout/AppHeader.js
+++ b/src/layout/AppHeader.js
@@ -25,6 +25,5 @@ const styles = StyleSheet.create({
     paddingTop: appHeaderHeight,
     paddingHorizontal: 10,
     backgroundColor: HEADER,
-    borderBottomWidth: 0.2,
   },
 });

--- a/src/pages/Editor.js
+++ b/src/pages/Editor.js
@@ -12,6 +12,7 @@ import {
 } from "react-native";
 
 import GifEditor from "./GifEditor";
+import ImageEditor from "./ImageEditor";
 import TextEditor from "./TextEditor";
 import api from "../api/index";
 import { ACTIVE_COLOR, CONTENT } from "../constants/color";
@@ -28,6 +29,8 @@ export default function Editor({ navigation }) {
   const [selectedController, setSelectedController] = useState("");
   const [isTextEditable, setIsTextEditalbe] = useState(false);
   const [isGifGettable, setIsGifGettable] = useState(false);
+  const [isImageEditable, setisImageEditable] = useState(false);
+
   const [selectedTextProperty, setSelectedTextProperty] = useState("");
   const [selectedTextSize, setSelectedTextSize] = useState(0);
   const [selectedTextElement, setSelectedTextElement] = useState(null);
@@ -49,12 +52,20 @@ export default function Editor({ navigation }) {
 
     if (name === "Text") {
       setIsGifGettable(false);
+      setisImageEditable(false);
       setIsTextEditalbe(!isTextEditable);
     }
 
     if (name === "Gif") {
       setIsTextEditalbe(false);
+      setisImageEditable(false);
       getGifs();
+    }
+
+    if (name === "Image") {
+      setIsGifGettable(false);
+      setIsTextEditalbe(false);
+      setisImageEditable(!isImageEditable);
     }
   };
 
@@ -148,6 +159,11 @@ export default function Editor({ navigation }) {
       {isGifGettable && (
         <View style={styles.gifEditorContainer}>
           <GifEditor gifURLs={gifURLs} />
+        </View>
+      )}
+      {isImageEditable && (
+        <View style={styles.gifEditorContainer}>
+          <ImageEditor />
         </View>
       )}
       <AppFooter>

--- a/src/pages/GifEditor.js
+++ b/src/pages/GifEditor.js
@@ -67,7 +67,7 @@ export default function GifEditor({ gifURLs }) {
           >
             <View style={styles.gridContainer}>
               {animationData.map((data, index) => (
-                <View style={styles.gridItem} key={index}>
+                <TouchableOpacity style={styles.gridItem} key={index}>
                   <Lottie
                     key={data + index + 1}
                     ref={(element) => (animationRefs.current[index] = element)}
@@ -77,7 +77,7 @@ export default function GifEditor({ gifURLs }) {
                     autoPlay
                     loop
                   />
-                </View>
+                </TouchableOpacity>
               ))}
             </View>
           </ScrollView>

--- a/src/pages/ImageEditor.js
+++ b/src/pages/ImageEditor.js
@@ -1,0 +1,252 @@
+import {
+  FontAwesome,
+  MaterialCommunityIcons,
+  Ionicons,
+} from "@expo/vector-icons";
+import { useState, useEffect } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Dimensions,
+  ScrollView,
+  TouchableOpacity,
+  Image,
+  TextInput,
+} from "react-native";
+
+import api from "../api";
+import { ACTIVE_COLOR, EDITOR_COLOR } from "../constants/color";
+import { imageEditor } from "../constants/footerItems";
+
+const { width: screenWidth, height: screenHeight } = Dimensions.get("window");
+const appFooterHeight = screenHeight / 12;
+
+export default function ImageEditor() {
+  const [selectedProperty, setSelectedProperty] = useState("");
+  const [imageDimensions, setImageDimensions] = useState([]);
+  const [photos, setPhotos] = useState([]);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const handleSelectedProperty = (name) => {
+    if (selectedProperty === name) {
+      setSelectedProperty("");
+    }
+
+    if (selectedProperty !== name) {
+      setSelectedProperty(name);
+    }
+  };
+
+  const getImageSize = (uri) => {
+    return new Promise((resolve, reject) => {
+      Image.getSize(
+        uri,
+        (width, height) => {
+          resolve({ uri, width, height });
+        },
+        (error) => {
+          reject(error);
+        },
+      );
+    });
+  };
+
+  async function fetchImageDimensions() {
+    try {
+      const dimensions = await Promise.all(
+        photos.map(async (uri) => {
+          const { width, height } = await getImageSize(uri);
+          return { uri, width, height };
+        }),
+      );
+
+      setImageDimensions(dimensions);
+    } catch (error) {
+      console.error("Error fetching image dimensions:", error);
+    }
+  }
+
+  async function handleSearch() {
+    try {
+      const response = await api.searchImages(searchQuery);
+
+      const images = response.data.results.map((item) => item.urls.small);
+      setPhotos(images);
+    } catch (error) {
+      console.error("Error searching photos:", error);
+    }
+  }
+
+  useEffect(() => {
+    async function fetchPhotos() {
+      try {
+        const response = await api.getImages();
+
+        const image = response.data.map((item) => item.urls.small);
+
+        setPhotos(image);
+      } catch (error) {
+        console.error("Error fetching photos:", error);
+      }
+    }
+
+    fetchPhotos();
+  }, []);
+
+  useEffect(() => {
+    fetchImageDimensions();
+  }, [photos]);
+
+  return (
+    <View>
+      {selectedProperty === "Unsplash" && photos.length > 0 && (
+        <View style={styles.container}>
+          <View style={styles.paddingContainer}>
+            <TextInput
+              style={styles.searchBar}
+              onChangeText={setSearchQuery}
+              value={searchQuery}
+              onSubmitEditing={handleSearch}
+              placeholder="Search Unsplash"
+            />
+            <ScrollView
+              pagingEnabled
+              contentContainerStyle={styles.scrollViewContainer}
+            >
+              <View style={styles.gridContainer}>
+                {imageDimensions.map((item, index) => (
+                  <TouchableOpacity
+                    style={styles.gridItem}
+                    key={item.uri + index}
+                  >
+                    <Image
+                      style={{
+                        ...styles.image,
+                        width: screenWidth * 0.8,
+                        height: (screenWidth * 0.8 * item.height) / item.width,
+                      }}
+                      source={{ uri: item.uri }}
+                    />
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </ScrollView>
+          </View>
+        </View>
+      )}
+      <View style={styles.controllerContainer}>
+        {imageEditor.map((item) => (
+          <TouchableOpacity
+            onPress={() => handleSelectedProperty(item.text)}
+            key={item.iconName}
+            style={styles.iconWithText}
+          >
+            {item.icon === "FontAwesome" && (
+              <FontAwesome
+                name={item.iconName}
+                size={30}
+                color={selectedProperty === item.text ? ACTIVE_COLOR : "gray"}
+              />
+            )}
+            {item.icon === "MaterialCommunityIcons" && (
+              <MaterialCommunityIcons
+                name={item.iconName}
+                size={30}
+                color={selectedProperty === item.text ? ACTIVE_COLOR : "gray"}
+              />
+            )}
+            {item.icon === "Ionicons" && (
+              <Ionicons
+                name={item.iconName}
+                size={30}
+                color={selectedProperty === item.text ? ACTIVE_COLOR : "gray"}
+              />
+            )}
+            <Text
+              style={{
+                ...styles.iconText,
+                color: selectedProperty === item.text ? ACTIVE_COLOR : "gray",
+              }}
+            >
+              {item.text}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    justifyContent: "space-around",
+    alignItems: "center",
+    width: screenWidth,
+    height: (screenHeight * 2) / 3,
+    backgroundColor: EDITOR_COLOR,
+    shadowColor: "#000",
+    shadowOffset: {
+      width: 0,
+      height: -4,
+    },
+    shadowOpacity: 0.15,
+    shadowRadius: 3,
+    borderTopRightRadius: 30,
+    borderTopLeftRadius: 30,
+  },
+  paddingContainer: {
+    paddingTop: 20,
+    alignItems: "center",
+  },
+  searchBar: {
+    width: screenWidth * 0.8,
+    height: screenHeight * 0.05,
+    backgroundColor: EDITOR_COLOR,
+    paddingHorizontal: 10,
+    borderWidth: 2,
+    borderRadius: 10,
+    marginBottom: 20,
+  },
+  scrollViewContainer: {
+    paddingHorizontal: 20,
+  },
+  gridContainer: {
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  gridItem: {
+    width: screenWidth * 0.8,
+    marginBottom: 20,
+    backgroundColor: "gray",
+  },
+  image: {
+    width: "100%",
+    height: "100%",
+  },
+  controllerContainer: {
+    flexDirection: "row",
+    justifyContent: "space-around",
+    alignItems: "center",
+    width: screenWidth,
+    height: appFooterHeight,
+    backgroundColor: EDITOR_COLOR,
+    shadowColor: "#000",
+    shadowOffset: {
+      width: 0,
+      height: -2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 3,
+  },
+  iconWithText: {
+    flex: 1,
+    alignItems: "center",
+  },
+  iconText: {
+    marginTop: 5,
+    fontSize: 12,
+    color: "gray",
+  },
+});


### PR DESCRIPTION
## 📝 Description
- `ImageEditor`의 정적 페이지를 완성하였습니다. 
- `Unsplash API`를 사용해 `Unsplash`의 `Image`에 접근할 수 있게 하였습니다.
- `SearchBar`를 이용해 원하는 이미지를 검색해 새로운 이미지로 만들 수 있게 하였습니다.
- 이미지가 가지고 있던 비율 그대로 가져오기 위해 `Image.getSize`속성을 이용해 `width`와 `height`를 가져오고 이를 이용해 현재 화면에 맞는 비율로 조정하였습니다.

## ❗ Related Issues
- 선택한 이미지를 화면에 추가 시키는 버튼이 필요합니다.

## 🛠️ Changes
- `Appheader`의 `borderBottom`이 시야적으로 통일성을 헤친다고 생각하여 제거하였습니다.

## 📸 Screenshot

<img src="https://user-images.githubusercontent.com/113571767/231530947-296bacab-d497-46c8-9fd8-488cbc6b7e80.png" width=400>
